### PR TITLE
fix: prevent type error on the arrow button

### DIFF
--- a/static/calculator.js
+++ b/static/calculator.js
@@ -70,7 +70,8 @@ function handleSymbol(value) {
       if (buffer.length === 1) {
         buffer = "0";
       } else {
-        buffer = buffer.substring(0, buffer.length - 1);
+        const bufferString = buffer.toString()
+        buffer = bufferString.substring(0, bufferString.length - 1);
       }
       break;
     case "+":


### PR DESCRIPTION
Fixes a type error bug when the user clicks on the arrow button after calculating the result of a previous operation.